### PR TITLE
Dictionary Vars in Protocol Definitions now parsed correctly

### DIFF
--- a/Parrot.xcodeproj/project.pbxproj
+++ b/Parrot.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		9F1555EF20B84D5B0032CB9E /* MapForDuplicateFunctionNamesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1555EE20B84D5B0032CB9E /* MapForDuplicateFunctionNamesTests.swift */; };
 		9F209C0B20937E9D00847DDF /* StringIndexExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F209C0920937D2F00847DDF /* StringIndexExtensions.swift */; };
 		9F211E5E1FC4ABDE003352DC /* DataStructures.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37BAE201FBFA8B600EA8A91 /* DataStructures.swift */; };
+		9F2FD5AC218FAA77008DFD67 /* MockSomeOptionalThings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2FD5AB218FAA77008DFD67 /* MockSomeOptionalThings.swift */; };
 		9F8168412096BD6300C4B8D7 /* DictionaryExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8168402096BD6300C4B8D7 /* DictionaryExamples.swift */; };
 		9F8168432096BF4E00C4B8D7 /* MockDictionaryExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8168422096BF4E00C4B8D7 /* MockDictionaryExamples.swift */; };
 		9F8168452096BF5E00C4B8D7 /* MockComplexDictionaryExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8168442096BF5E00C4B8D7 /* MockComplexDictionaryExamples.swift */; };
@@ -91,6 +92,7 @@
 		9F0B7ADA209354810029DAD9 /* MockExampleDataFetchWithMultipleCompletionParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExampleDataFetchWithMultipleCompletionParameters.swift; sourceTree = "<group>"; };
 		9F1555EE20B84D5B0032CB9E /* MapForDuplicateFunctionNamesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapForDuplicateFunctionNamesTests.swift; sourceTree = "<group>"; };
 		9F209C0920937D2F00847DDF /* StringIndexExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringIndexExtensions.swift; sourceTree = "<group>"; };
+		9F2FD5AB218FAA77008DFD67 /* MockSomeOptionalThings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSomeOptionalThings.swift; sourceTree = "<group>"; };
 		9F8168402096BD6300C4B8D7 /* DictionaryExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExamples.swift; sourceTree = "<group>"; };
 		9F8168422096BF4E00C4B8D7 /* MockDictionaryExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDictionaryExamples.swift; sourceTree = "<group>"; };
 		9F8168442096BF5E00C4B8D7 /* MockComplexDictionaryExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockComplexDictionaryExamples.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				9F8168422096BF4E00C4B8D7 /* MockDictionaryExamples.swift */,
 				9F8168442096BF5E00C4B8D7 /* MockComplexDictionaryExamples.swift */,
 				9F81684E20980D6000C4B8D7 /* MockOverloadedFunctionsExample.swift */,
+				9F2FD5AB218FAA77008DFD67 /* MockSomeOptionalThings.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -467,6 +470,7 @@
 				9F8F00CF2040DA000030B39B /* parrot-defaults.swift in Sources */,
 				9F8F00C32040D2150030B39B /* CompletionExamples.swift in Sources */,
 				9F211E5E1FC4ABDE003352DC /* DataStructures.swift in Sources */,
+				9F2FD5AC218FAA77008DFD67 /* MockSomeOptionalThings.swift in Sources */,
 				F37BAE141FBFA0AC00EA8A91 /* FileOperations.swift in Sources */,
 				F36CDCC61FCD04A20075360E /* MockGenerator.swift in Sources */,
 				9FF6C7DF2093C9C70026D72E /* ArrayExtensions.swift in Sources */,

--- a/Parrot/Mock Generation/VariableGenerator.swift
+++ b/Parrot/Mock Generation/VariableGenerator.swift
@@ -29,10 +29,17 @@ extension Variable {
     }
     
     var stubEntries: [String] {
-        let returnValue = self.defaultReturnValue ?? "<#Default return value#>"
+        let assignmentText = " = "
+        let returnValue: String
+        if let defaultReturnValue = self.defaultReturnValue {
+            returnValue = defaultReturnValue != "nil" ? "\(assignmentText)\(defaultReturnValue)" : ""
+        } else {
+            returnValue = "\(assignmentText)<#Default return value#>"
+        }
+        
         return [
             "var \(name)CallCount = 0",
-            "var \(name)ShouldReturn: \(type) = \(returnValue)"
+            "var \(name)ShouldReturn: \(type)\(returnValue)"
         ]
     }
     

--- a/Parrot/Parsing/VariableParser.swift
+++ b/Parrot/Parsing/VariableParser.swift
@@ -3,28 +3,25 @@ import Foundation
 extension Variable {
     
     static func from(declaration: String, defaultsTable: [String: String]) -> Variable? {
-    
-        let colon = CharacterSet(charactersIn: ":")
         let specialCharacters = CharacterSet(charactersIn: ":{},")
         
-        let variableInfo = declaration.components(separatedBy: colon).filter { $0 != "" }
+        func equalsColon(character: Character) -> Bool { return character == ":" }
+        let variableInfo = declaration.split(maxSplits: 1, omittingEmptySubsequences: true, whereSeparator: equalsColon)
         
         guard let modifierAndName = variableInfo.first?.components(separatedBy: specialCharacters.union(.whitespacesAndNewlines)),
-            let typeAndGetSetInfo = variableInfo.last?.components(separatedBy: specialCharacters.union(.whitespacesAndNewlines))
+            let typeAndGetSetInfo = variableInfo.last?.split(maxSplits: 1, omittingEmptySubsequences: true, whereSeparator: { $0 == "{" }),
+            let type = typeAndGetSetInfo.first?.toTrimmedString,
+            let getSetInfo = typeAndGetSetInfo.last?.toTrimmedString
         else { return nil }
         
         let filteredModifierAndName = modifierAndName.filter { $0 != "" }
-        let filteredTypeAndGetSetInfo = typeAndGetSetInfo.filter { $0 != "" }
+
+        guard let name = filteredModifierAndName.last else { return nil }
         
-        guard let name = filteredModifierAndName.last, let type = filteredTypeAndGetSetInfo.first else { return nil }
-        
-        if filteredModifierAndName.contains("func") ||
-            !filteredModifierAndName.contains("var") ||
-            !filteredTypeAndGetSetInfo.contains("get")
-            { return nil  }
+        guard (filteredModifierAndName.first?.hasPrefix("func ") == false), filteredModifierAndName.contains("var"), getSetInfo.contains("get") else { return nil }
         
         let isWeak = filteredModifierAndName.contains("weak")
-        let isGetSet = filteredTypeAndGetSetInfo.contains("set")
+        let isGetSet = getSetInfo.contains("set")
         
         // TODO: Where is the best place structure wise to put this
         let defaultReturnValue = defaultsTable[type] ?? KnownType.from(declaration: type)?.defaultReturnValue

--- a/ParrotTests/Mock Generation Tests/VariableGeneratorTests.swift
+++ b/ParrotTests/Mock Generation Tests/VariableGeneratorTests.swift
@@ -104,4 +104,14 @@ class VariableGeneratorTests: XCTestCase {
         XCTAssertEqual(result, ["var \(expectedVariableName)CallCount = 0",
             "var \(expectedVariableName)ShouldReturn: \(expectedVariableType) = <#Default return value#>"])
     }
+    
+    func testStubEntities_WhenOptionalVariable_ThenNoAssignmentStatement() {
+        let expectedVariableType = "String?"
+        let testVariable = Variable(name: expectedVariableName, type: expectedVariableType, defaultReturnValue: KnownType.from(declaration: expectedVariableType)?.defaultReturnValue, isGetSet: false, isWeak: false)
+        
+        let result = testVariable.stubEntries
+        
+        XCTAssertEqual(result, ["var \(expectedVariableName)CallCount = 0",
+            "var \(expectedVariableName)ShouldReturn: \(expectedVariableType)"])
+    }
 }

--- a/ParrotTests/Parsing Tests/VariableParserTests.swift
+++ b/ParrotTests/Parsing Tests/VariableParserTests.swift
@@ -78,29 +78,66 @@ class VariableParserTests: XCTestCase {
         XCTAssertEqual(result.defaultReturnValue, "nil")
     }
     
-    // TODO: Support Dictionaries as return values for variables
+    // MARK: - Dictionary Variables
     
-//    func testWhenVarWithDictionaryReturnIsPassed_ThenCorrectVariableIsCreated() {
-//        let declaration = "var myDict : [Int:String] {  get  } "
-//        guard let result = Variable.from(declaration: declaration) else { XCTFail(); return }
-//
-//        XCTAssertEqual(result.name, "myDict")
-//        XCTAssertEqual(result.type, "[Int:String]")
-//        XCTAssertEqual(result.isWeak, false)
-//        XCTAssertEqual(result.isGetSet, false)
-//        XCTAssertEqual(result.defaultReturnValue, "[:]")
-//    }
-//
-//    func testWhenVarWithOptionalDictionaryReturnIsPassed_ThenCorrectVariableIsCreated() {
-//        let declaration = "var myDict : [Int:Double]? {  get  } "
-//        guard let result = Variable.from(declaration: declaration) else { XCTFail(); return }
-//
-//        XCTAssertEqual(result.name, "myDict")
-//        XCTAssertEqual(result.type, "[Int:Double]")
-//        XCTAssertEqual(result.isWeak, false)
-//        XCTAssertEqual(result.isGetSet, false)
-//        XCTAssertEqual(result.defaultReturnValue, "nil")
-//    }
+    func testWhenVarWithDictionaryReturnIsPassed_ThenCorrectVariableIsCreated() {
+        let declaration = "var myDict: [Int: String] { get } "
+        
+        guard let result = Variable.from(declaration: declaration, defaultsTable: [:]) else { XCTFail(); return }
+
+        XCTAssertEqual(result.name, "myDict")
+        XCTAssertEqual(result.type, "[Int: String]")
+        XCTAssertEqual(result.isWeak, false)
+        XCTAssertEqual(result.isGetSet, false)
+        XCTAssertEqual(result.defaultReturnValue, "[:]")
+    }
+    
+    func testWhenVarWithDictionaryReturnIsPassed_GetSet_ThenCorrectVariableIsCreated() {
+        let declaration = "var myDict: [Int: String] { get set } "
+        
+        guard let result = Variable.from(declaration: declaration, defaultsTable: [:]) else { XCTFail(); return }
+        
+        XCTAssertEqual(result.name, "myDict")
+        XCTAssertEqual(result.type, "[Int: String]")
+        XCTAssertEqual(result.isWeak, false)
+        XCTAssertEqual(result.isGetSet, true)
+        XCTAssertEqual(result.defaultReturnValue, "[:]")
+    }
+    
+    func testWhenVarWithDictionaryReturnIsPassed_Weak_ThenCorrectVariableIsCreated() {
+        let declaration = "weak var myDict: [Int: String] { get } "
+        
+        guard let result = Variable.from(declaration: declaration, defaultsTable: [:]) else { XCTFail(); return }
+        
+        XCTAssertEqual(result.name, "myDict")
+        XCTAssertEqual(result.type, "[Int: String]")
+        XCTAssertEqual(result.isWeak, true)
+        XCTAssertEqual(result.isGetSet, false)
+        XCTAssertEqual(result.defaultReturnValue, "[:]")
+    }
+    
+    func testWhenVarWithOptionalDictionaryReturnIsPassed_GetSet_Weak_ThenCorrectVariableIsCreated() {
+        let declaration = "weak var myDict: [Int: String]? { get set } "
+        
+        guard let result = Variable.from(declaration: declaration, defaultsTable: [:]) else { XCTFail(); return }
+        
+        XCTAssertEqual(result.name, "myDict")
+        XCTAssertEqual(result.type, "[Int: String]?")
+        XCTAssertEqual(result.isWeak, true)
+        XCTAssertEqual(result.isGetSet, true)
+        XCTAssertEqual(result.defaultReturnValue, "nil")
+    }
+
+    func testWhenVarWithOptionalDictionaryReturnIsPassed_ThenCorrectVariableIsCreated() {
+        let declaration = "var myDict : [Int:Double]? {  get  } "
+        guard let result = Variable.from(declaration: declaration, defaultsTable: [:]) else { XCTFail(); return }
+
+        XCTAssertEqual(result.name, "myDict")
+        XCTAssertEqual(result.type, "[Int:Double]?")
+        XCTAssertEqual(result.isWeak, false)
+        XCTAssertEqual(result.isGetSet, false)
+        XCTAssertEqual(result.defaultReturnValue, "nil")
+    }
     
     func testWhenVarWithSetReturnIsPassed_ThenCorrectVariableIsCreated() {
         let declaration = "var mySet: Set<Int> {  get  } "

--- a/ParrotTests/RunExamples/Implementation/DictionaryExamples.swift
+++ b/ParrotTests/RunExamples/Implementation/DictionaryExamples.swift
@@ -1,4 +1,6 @@
 protocol DictionaryExamples {
+    var varGetDictionary: [String: String] { get }
+    var varGetSetDictionary: [String: String] { get set }
     func testDictionarySimple(myDictionary: [String: Any])
     func testDictionaryReturnSimple() -> [String: Any]
     func testDictionaryDictionaryArgAndReturn(my dictionary: [String: [String]]) -> [Int: [Int]]

--- a/ParrotTests/RunExamples/Implementation/Implementation.swift
+++ b/ParrotTests/RunExamples/Implementation/Implementation.swift
@@ -26,3 +26,20 @@ protocol SomeProtocol: class {
 struct AmazingStruct {
     // I'm boring
 }
+
+protocol SomeOptionalThings {
+    var myVariable: String? { get }
+    var myGetSet: String? { get set }
+    
+    var myArrayGet: [String]? { get }
+    var myArrayGetOptionalElement: [String?] { get }
+    var myDictionaryGet: [String: String]? { get }
+    var myDictionaryGetOptionalValue: [String: String?] { get }
+    var myDictionaryGetOptionalValueAndSelf: [String: String?]? { get }
+    var mySetOfDoublesGet: Set<Double>? { get }
+    var mySetOfDoublesGetOptionalElement: Set<Double?> { get }
+    
+    weak var myWeakGet: AmazingClass? { get }
+    weak var myWeakGetSet: AmazingClass? { get set }
+    
+}

--- a/ParrotTests/RunExamples/Tests/MockDictionaryExamples.swift
+++ b/ParrotTests/RunExamples/Tests/MockDictionaryExamples.swift
@@ -3,7 +3,10 @@
 class MockSimpleDictionaryExamples: DictionaryExamples {
 
 	final class Stub {
-		
+		var varGetDictionaryCallCount = 0
+		var varGetDictionaryShouldReturn: [String: String] = [:]
+		var varGetSetDictionaryCallCount = 0
+		var varGetSetDictionaryShouldReturn: [String: String] = [:]
 		var testDictionarySimpleCallCount = 0
 		var testDictionarySimpleCalledWith = [[String: Any]]()
 		var testDictionaryReturnSimpleCallCount = 0
@@ -17,6 +20,21 @@ class MockSimpleDictionaryExamples: DictionaryExamples {
 	}
 
 	var stub = Stub()
+
+	var varGetSetDictionary: [String: String] {
+		get {
+			stub.varGetSetDictionaryCallCount += 1
+			return stub.varGetSetDictionaryShouldReturn
+		}
+		set {
+			stub.varGetSetDictionaryShouldReturn = newValue
+		}
+	}
+
+	var varGetDictionary: [String: String] {
+		stub.varGetDictionaryCallCount += 1
+		return stub.varGetDictionaryShouldReturn
+	}
 
 	func testDictionarySimple(myDictionary: [String: Any]) {
 		stub.testDictionarySimpleCallCount += 1

--- a/ParrotTests/RunExamples/Tests/MockSomeOptionalThings.swift
+++ b/ParrotTests/RunExamples/Tests/MockSomeOptionalThings.swift
@@ -1,0 +1,99 @@
+
+//@@parrot-mock
+final class MockSomeOptionalThings: SomeOptionalThings {
+
+	final class Stub {
+		var myVariableCallCount = 0
+		var myVariableShouldReturn: String?
+		var myGetSetCallCount = 0
+		var myGetSetShouldReturn: String?
+		var myArrayGetCallCount = 0
+		var myArrayGetShouldReturn: [String]?
+		var myArrayGetOptionalElementCallCount = 0
+		var myArrayGetOptionalElementShouldReturn: [String?] = []
+		var myDictionaryGetCallCount = 0
+		var myDictionaryGetShouldReturn: [String: String]?
+		var myDictionaryGetOptionalValueCallCount = 0
+		var myDictionaryGetOptionalValueShouldReturn: [String: String?] = [:]
+		var myDictionaryGetOptionalValueAndSelfCallCount = 0
+		var myDictionaryGetOptionalValueAndSelfShouldReturn: [String: String?]?
+		var mySetOfDoublesGetCallCount = 0
+		var mySetOfDoublesGetShouldReturn: Set<Double>?
+		var mySetOfDoublesGetOptionalElementCallCount = 0
+		var mySetOfDoublesGetOptionalElementShouldReturn: Set<Double?> = []
+		var myWeakGetCallCount = 0
+		var myWeakGetShouldReturn: AmazingClass?
+		var myWeakGetSetCallCount = 0
+		var myWeakGetSetShouldReturn: AmazingClass?
+		
+	}
+
+	var stub = Stub()
+
+	var myGetSet: String? {
+		get {
+			stub.myGetSetCallCount += 1
+			return stub.myGetSetShouldReturn
+		}
+		set {
+			stub.myGetSetShouldReturn = newValue
+		}
+	}
+
+	weak var myWeakGetSet: AmazingClass? {
+		get {
+			stub.myWeakGetSetCallCount += 1
+			return stub.myWeakGetSetShouldReturn
+		}
+		set {
+			stub.myWeakGetSetShouldReturn = newValue
+		}
+	}
+
+	var mySetOfDoublesGetOptionalElement: Set<Double?> {
+		stub.mySetOfDoublesGetOptionalElementCallCount += 1
+		return stub.mySetOfDoublesGetOptionalElementShouldReturn
+	}
+
+	var mySetOfDoublesGet: Set<Double>? {
+		stub.mySetOfDoublesGetCallCount += 1
+		return stub.mySetOfDoublesGetShouldReturn
+	}
+
+	var myDictionaryGetOptionalValueAndSelf: [String: String?]? {
+		stub.myDictionaryGetOptionalValueAndSelfCallCount += 1
+		return stub.myDictionaryGetOptionalValueAndSelfShouldReturn
+	}
+
+	var myDictionaryGetOptionalValue: [String: String?] {
+		stub.myDictionaryGetOptionalValueCallCount += 1
+		return stub.myDictionaryGetOptionalValueShouldReturn
+	}
+
+	var myDictionaryGet: [String: String]? {
+		stub.myDictionaryGetCallCount += 1
+		return stub.myDictionaryGetShouldReturn
+	}
+
+	var myArrayGetOptionalElement: [String?] {
+		stub.myArrayGetOptionalElementCallCount += 1
+		return stub.myArrayGetOptionalElementShouldReturn
+	}
+
+	var myArrayGet: [String]? {
+		stub.myArrayGetCallCount += 1
+		return stub.myArrayGetShouldReturn
+	}
+
+	var myVariable: String? {
+		stub.myVariableCallCount += 1
+		return stub.myVariableShouldReturn
+	}
+
+	weak var myWeakGet: AmazingClass? {
+		stub.myWeakGetCallCount += 1
+		return stub.myWeakGetShouldReturn
+	}
+
+
+}

--- a/ParrotTests/RunExamples/Tests/TestFile.swift
+++ b/ParrotTests/RunExamples/Tests/TestFile.swift
@@ -16,9 +16,9 @@ final class MockModel: SomeProtocol {
 		var mySetOfDoublesGetCallCount = 0
 		var mySetOfDoublesGetShouldReturn: Set<Double> = []
 		var myWeakGetCallCount = 0
-		var myWeakGetShouldReturn: AmazingClass? = nil
+		var myWeakGetShouldReturn: AmazingClass?
 		var myWeakGetSetCallCount = 0
-		var myWeakGetSetShouldReturn: AmazingClass? = nil
+		var myWeakGetSetShouldReturn: AmazingClass?
 		var myBasicFuncCallCount = 0
 		var myBasicFuncTwoCallCount = 0
 		var myBasicFuncTwoCalledWith = [String]()


### PR DESCRIPTION
Fixes #1 
Small enhancement to remove unneeded ` = nil` when defining stubs with optional types