### PR TITLE
allows internal modifier on protocols, supports protocol composition,…

### DIFF
--- a/Parrot.xcodeproj/project.pbxproj
+++ b/Parrot.xcodeproj/project.pbxproj
@@ -13,6 +13,10 @@
 		9F209C0B20937E9D00847DDF /* StringIndexExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F209C0920937D2F00847DDF /* StringIndexExtensions.swift */; };
 		9F211E5E1FC4ABDE003352DC /* DataStructures.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37BAE201FBFA8B600EA8A91 /* DataStructures.swift */; };
 		9F2FD5AC218FAA77008DFD67 /* MockSomeOptionalThings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2FD5AB218FAA77008DFD67 /* MockSomeOptionalThings.swift */; };
+		9F2FD5AE218FB7C4008DFD67 /* CompositionExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2FD5AD218FB7C4008DFD67 /* CompositionExamples.swift */; };
+		9F2FD5B0218FB83F008DFD67 /* MockMyConformingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2FD5AF218FB83F008DFD67 /* MockMyConformingProtocol.swift */; };
+		9F2FD5B2218FCD96008DFD67 /* MockNestedConformingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2FD5B1218FCD96008DFD67 /* MockNestedConformingProtocol.swift */; };
+		9F2FD5B4218FFB65008DFD67 /* MockMySecondConformingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2FD5B3218FFB65008DFD67 /* MockMySecondConformingProtocol.swift */; };
 		9F8168412096BD6300C4B8D7 /* DictionaryExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8168402096BD6300C4B8D7 /* DictionaryExamples.swift */; };
 		9F8168432096BF4E00C4B8D7 /* MockDictionaryExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8168422096BF4E00C4B8D7 /* MockDictionaryExamples.swift */; };
 		9F8168452096BF5E00C4B8D7 /* MockComplexDictionaryExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8168442096BF5E00C4B8D7 /* MockComplexDictionaryExamples.swift */; };
@@ -93,6 +97,10 @@
 		9F1555EE20B84D5B0032CB9E /* MapForDuplicateFunctionNamesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapForDuplicateFunctionNamesTests.swift; sourceTree = "<group>"; };
 		9F209C0920937D2F00847DDF /* StringIndexExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringIndexExtensions.swift; sourceTree = "<group>"; };
 		9F2FD5AB218FAA77008DFD67 /* MockSomeOptionalThings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSomeOptionalThings.swift; sourceTree = "<group>"; };
+		9F2FD5AD218FB7C4008DFD67 /* CompositionExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositionExamples.swift; sourceTree = "<group>"; };
+		9F2FD5AF218FB83F008DFD67 /* MockMyConformingProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMyConformingProtocol.swift; sourceTree = "<group>"; };
+		9F2FD5B1218FCD96008DFD67 /* MockNestedConformingProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNestedConformingProtocol.swift; sourceTree = "<group>"; };
+		9F2FD5B3218FFB65008DFD67 /* MockMySecondConformingProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMySecondConformingProtocol.swift; sourceTree = "<group>"; };
 		9F8168402096BD6300C4B8D7 /* DictionaryExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExamples.swift; sourceTree = "<group>"; };
 		9F8168422096BF4E00C4B8D7 /* MockDictionaryExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDictionaryExamples.swift; sourceTree = "<group>"; };
 		9F8168442096BF5E00C4B8D7 /* MockComplexDictionaryExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockComplexDictionaryExamples.swift; sourceTree = "<group>"; };
@@ -176,6 +184,7 @@
 				9F8F00D02040DA2E0030B39B /* CustomTypesExamples.swift */,
 				9F8168402096BD6300C4B8D7 /* DictionaryExamples.swift */,
 				9F81684C20980D1200C4B8D7 /* OverloadedFunctionsExample.swift */,
+				9F2FD5AD218FB7C4008DFD67 /* CompositionExamples.swift */,
 			);
 			path = Implementation;
 			sourceTree = "<group>";
@@ -194,6 +203,9 @@
 				9F8168442096BF5E00C4B8D7 /* MockComplexDictionaryExamples.swift */,
 				9F81684E20980D6000C4B8D7 /* MockOverloadedFunctionsExample.swift */,
 				9F2FD5AB218FAA77008DFD67 /* MockSomeOptionalThings.swift */,
+				9F2FD5AF218FB83F008DFD67 /* MockMyConformingProtocol.swift */,
+				9F2FD5B1218FCD96008DFD67 /* MockNestedConformingProtocol.swift */,
+				9F2FD5B3218FFB65008DFD67 /* MockMySecondConformingProtocol.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -466,12 +478,15 @@
 				F36CDCC31FCD04600075360E /* VariableParserTests.swift in Sources */,
 				F37BAE181FBFA0B500EA8A91 /* FileManagerExtensions.swift in Sources */,
 				9F9A26EC20408DE6001034E4 /* ArgumentParsingTests.swift in Sources */,
+				9F2FD5B2218FCD96008DFD67 /* MockNestedConformingProtocol.swift in Sources */,
 				F38A45FF1FC8DCB50032162D /* BasicExamplesToCover.swift in Sources */,
 				9F8F00CF2040DA000030B39B /* parrot-defaults.swift in Sources */,
 				9F8F00C32040D2150030B39B /* CompletionExamples.swift in Sources */,
+				9F2FD5AE218FB7C4008DFD67 /* CompositionExamples.swift in Sources */,
 				9F211E5E1FC4ABDE003352DC /* DataStructures.swift in Sources */,
 				9F2FD5AC218FAA77008DFD67 /* MockSomeOptionalThings.swift in Sources */,
 				F37BAE141FBFA0AC00EA8A91 /* FileOperations.swift in Sources */,
+				9F2FD5B4218FFB65008DFD67 /* MockMySecondConformingProtocol.swift in Sources */,
 				F36CDCC61FCD04A20075360E /* MockGenerator.swift in Sources */,
 				9FF6C7DF2093C9C70026D72E /* ArrayExtensions.swift in Sources */,
 				9FF6C7DE2093C9C00026D72E /* EnclosingCharacter.swift in Sources */,
@@ -482,6 +497,7 @@
 				F34AD6F01FD32D3000630F4C /* FunctionGeneratorTests.swift in Sources */,
 				9F8F00D12040DA2E0030B39B /* CustomTypesExamples.swift in Sources */,
 				F36CDCC51FCD049F0075360E /* FunctionParser.swift in Sources */,
+				9F2FD5B0218FB83F008DFD67 /* MockMyConformingProtocol.swift in Sources */,
 				9F8F00C72040D2510030B39B /* MockExampleDataFetcherWithOtherParameter.swift in Sources */,
 				9F209C0B20937E9D00847DDF /* StringIndexExtensions.swift in Sources */,
 				1AB9403B201BB68400383019 /* StringExtensionTests.swift in Sources */,

--- a/Parrot/DataStructures.swift
+++ b/Parrot/DataStructures.swift
@@ -25,7 +25,7 @@ struct ProtocolEntity {
     let functions: [Function]
 }
 
-struct Variable {
+struct Variable: Hashable {
     let name: String
     let type: String
     let defaultReturnValue: String?
@@ -33,7 +33,7 @@ struct Variable {
     let isWeak: Bool
 }
 
-struct Function: Equatable {
+struct Function: Hashable {
     let name: String
     let baseStubMemberName: String
     let returnType: String?
@@ -49,7 +49,7 @@ struct Function: Equatable {
     }
 }
 
-struct Argument: Equatable {
+struct Argument: Hashable {
     let name: String
     let type: String
     let externalName: String?

--- a/Parrot/Parsing/ProtocolParser.swift
+++ b/Parrot/Parsing/ProtocolParser.swift
@@ -2,15 +2,13 @@ import Foundation
 
 struct ProtocolParser {
     
-    // TODO: handle nested type defs in the protocol
-
     static func protocolEntity(with protocolName: String, in files: [File], defaultsTable: [String: String]) -> ProtocolEntity? {
         
         let protocolEntities: [ProtocolEntity] = files.compactMap { (file) in
             
             let foundProtocol =  file.lines.enumerated().first { index, line in
                 let protocolDefinitionWithName = "protocol \(protocolName)"
-                return line.hasPrefix(protocolDefinitionWithName) || line.hasPrefix("public \(protocolDefinitionWithName)")
+                return line.hasPrefix(protocolDefinitionWithName) || line.hasPrefix("public \(protocolDefinitionWithName)") || line.hasPrefix("internal \(protocolDefinitionWithName)")
             }
             
             guard let lineNumber = foundProtocol?.offset else { return nil }
@@ -36,10 +34,34 @@ struct ProtocolParser {
                 return Function.from(declaration: line, defaultsTable: defaultsTable)
             }
             
-            return ProtocolEntity(file: file, name: protocolName, variables: variables, functions: functions)
+            let conformances = protocolConformances(fromProtocolFirstLine: filteredFileLines.first)
+            let protocolsToConformTo = conformances.compactMap { protocolEntity(with: $0, in: files, defaultsTable: defaultsTable) }
+            
+            let variablesFromConformances = protocolsToConformTo.flatMap { $0.variables }
+            let functionsFromConformances = protocolsToConformTo.flatMap { $0.functions }
+            let uniqueVariables = Array(Set<Variable>(variables + variablesFromConformances)).sorted { $0.name < $1.name }
+            let uniqueFunctions = Array(Set<Function>(functions + functionsFromConformances)).sorted { $0.name < $1.name }
+            
+            return ProtocolEntity(file: file, name: protocolName, variables: uniqueVariables, functions: uniqueFunctions)
         }
         
         return protocolEntities.first
     }
     
+    static func protocolConformances(fromProtocolFirstLine firstProtocolLine: String?) -> [String] {
+        guard
+            let splitByNameAndConformances = firstProtocolLine?.split(maxSplits: 1, omittingEmptySubsequences: true, whereSeparator: { $0 == ":" }),
+            splitByNameAndConformances.count > 1 else { return [] }
+        
+        guard let conformances = splitByNameAndConformances.last?
+            .toTrimmedString
+            .dropLast()
+            .components(separatedBy: ",")
+            .map({ $0.trimmed })
+        else { return [] }
+        
+        let conformancesWithoutClass = conformances.first == "class" ? conformances.dropFirst().map { $0 } : conformances
+
+        return conformancesWithoutClass
+    }
 }

--- a/ParrotTests/Parsing Tests/ProtocolParserTests.swift
+++ b/ParrotTests/Parsing Tests/ProtocolParserTests.swift
@@ -13,82 +13,136 @@ class ProtocolParserTests: XCTestCase {
         guard let entity = ProtocolParser.protocolEntity(with: "SomeProtocol", in: [testFileWithoutProtocol, testFileWithProtocolWithOnlyVariables], defaultsTable: [:]) else { XCTFail(); return }
         
         XCTAssertEqual(entity.name, "SomeProtocol")
-        if entity.variables.count != 4 { XCTFail(); return }
-        
-        XCTAssertEqual(entity.variables[0].name, "myVariable")
-        XCTAssertEqual(entity.variables[0].type, "String")
-        XCTAssertEqual(entity.variables[0].isGetSet, false)
-        XCTAssertEqual(entity.variables[0].isWeak, false)
-        
-        XCTAssertEqual(entity.variables[1].name, "myGetSet")
-        XCTAssertEqual(entity.variables[1].type, "Int")
-        XCTAssertEqual(entity.variables[1].isGetSet, true)
-        XCTAssertEqual(entity.variables[1].isWeak, false)
-        
-        XCTAssertEqual(entity.variables[2].name, "myWeakGet")
-        XCTAssertEqual(entity.variables[2].type, "AmazingClass?")
-        XCTAssertEqual(entity.variables[2].isGetSet, false)
-        XCTAssertEqual(entity.variables[2].isWeak, true)
-        
-        XCTAssertEqual(entity.variables[3].name, "myWeakGetSet")
-        XCTAssertEqual(entity.variables[3].type, "AmazingClass?")
-        XCTAssertEqual(entity.variables[3].isGetSet, true)
-        XCTAssertEqual(entity.variables[3].isWeak, true)
+        XCTAssertEqual(Set(entity.variables), [
+            Variable(name: "myVariable", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "myGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false),
+            Variable(name: "myWeakGet", type: "AmazingClass?", defaultReturnValue: "nil", isGetSet: false, isWeak: true),
+            Variable(name: "myWeakGetSet", type: "AmazingClass?", defaultReturnValue: "nil", isGetSet: true, isWeak: true)
+        ])
     }
     
-    func testWhenFilesContainSpecifiedProtocol_ThenCorrectEntityReturned2() {
+    func testWhenFilesContainSpecifiedProtocol_WhenClosingCurlyBraceNotIsolated_ThenCorrectEntityReturned() {
         
         guard let entity = ProtocolParser.protocolEntity(with: "SomeProtocol", in: [testFileWithoutProtocol, testFileWithProtocolWithClosingCurlyNotIsolated], defaultsTable: [:]) else { XCTFail(); return }
         
         XCTAssertEqual(entity.name, "SomeProtocol")
-        if entity.variables.count != 4 { XCTFail(); return }
-        
-        XCTAssertEqual(entity.variables[0].name, "myVariable")
-        XCTAssertEqual(entity.variables[0].type, "String")
-        XCTAssertEqual(entity.variables[0].isGetSet, false)
-        XCTAssertEqual(entity.variables[0].isWeak, false)
-        
-        XCTAssertEqual(entity.variables[1].name, "myGetSet")
-        XCTAssertEqual(entity.variables[1].type, "Int")
-        XCTAssertEqual(entity.variables[1].isGetSet, true)
-        XCTAssertEqual(entity.variables[1].isWeak, false)
-        
-        XCTAssertEqual(entity.variables[2].name, "myWeakGet")
-        XCTAssertEqual(entity.variables[2].type, "AmazingClass?")
-        XCTAssertEqual(entity.variables[2].isGetSet, false)
-        XCTAssertEqual(entity.variables[2].isWeak, true)
-        
-        XCTAssertEqual(entity.variables[3].name, "myWeakGetSet")
-        XCTAssertEqual(entity.variables[3].type, "AmazingClass?")
-        XCTAssertEqual(entity.variables[3].isGetSet, true)
-        XCTAssertEqual(entity.variables[3].isWeak, true)
+        XCTAssertEqual(Set(entity.variables), [
+            Variable(name: "myVariable", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "myGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false),
+            Variable(name: "myWeakGet", type: "AmazingClass?", defaultReturnValue: "nil", isGetSet: false, isWeak: true),
+            Variable(name: "myWeakGetSet", type: "AmazingClass?", defaultReturnValue: "nil", isGetSet: true, isWeak: true)
+        ])
     }
 
     func testWhenFileContainsSpecifiedProtocol_WhenPublic_ThenCorrectEntityReturned() {
         guard let entity = ProtocolParser.protocolEntity(with: "SomeProtocol", in: [testFileWithPublicProtocol], defaultsTable: [:]) else { XCTFail(); return }
         
         XCTAssertEqual(entity.name, "SomeProtocol")
-        if entity.variables.count != 4 { XCTFail(); return }
+        XCTAssertEqual(Set(entity.variables), [
+            Variable(name: "myVariable", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "myGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false),
+            Variable(name: "myWeakGet", type: "AmazingClass?", defaultReturnValue: "nil", isGetSet: false, isWeak: true),
+            Variable(name: "myWeakGetSet", type: "AmazingClass?", defaultReturnValue: "nil", isGetSet: true, isWeak: true)
+        ])
+    }
+    
+    func testProtocolEntity_WhenProtocolComposition_ThenHasDefinitionsFromBothProtocols() {
+        guard let entity = ProtocolParser.protocolEntity(with: "SomeProtocolComposition", in: [testFileWithProtocolComposition], defaultsTable: [:]) else { XCTFail(); return }
+     
+        XCTAssertEqual(Set(entity.variables), [
+            Variable(name: "myVariable", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "myGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false),
+            Variable(name: "composedGet", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "composedGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false)
+        ])
         
-        XCTAssertEqual(entity.variables[0].name, "myVariable")
-        XCTAssertEqual(entity.variables[0].type, "String")
-        XCTAssertEqual(entity.variables[0].isGetSet, false)
-        XCTAssertEqual(entity.variables[0].isWeak, false)
+        XCTAssertEqual(Set(entity.functions), [
+            Function(name: "woo", returnType: "Double?", arguments: [], defaultReturnValue: "nil"),
+            Function(name: "composedFunction", returnType: "Double?", arguments: [], defaultReturnValue: "nil")
+        ])
+    }
+    
+    func testProtocolEntity_WhenNestedProtocolComposition_ThenHasDefinitionsFromAllThreeProtocols() {
+        guard let entity = ProtocolParser.protocolEntity(with: "SomeProtocolComposition", in: [testFileWithNestedProtocolComposition], defaultsTable: [:]) else { XCTFail(); return }
         
-        XCTAssertEqual(entity.variables[1].name, "myGetSet")
-        XCTAssertEqual(entity.variables[1].type, "Int")
-        XCTAssertEqual(entity.variables[1].isGetSet, true)
-        XCTAssertEqual(entity.variables[1].isWeak, false)
+        XCTAssertEqual(Set(entity.variables), [
+            Variable(name: "myVariable", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "myGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false),
+            Variable(name: "composedGet", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "composedGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false),
+            Variable(name: "nestedGet", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "nestedGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false)
+        ])
         
-        XCTAssertEqual(entity.variables[2].name, "myWeakGet")
-        XCTAssertEqual(entity.variables[2].type, "AmazingClass?")
-        XCTAssertEqual(entity.variables[2].isGetSet, false)
-        XCTAssertEqual(entity.variables[2].isWeak, true)
+        XCTAssertEqual(Set(entity.functions), [
+            Function(name: "woo", returnType: "Double?", arguments: [], defaultReturnValue: "nil"),
+            Function(name: "composedFunction", returnType: "Double?", arguments: [], defaultReturnValue: "nil"),
+            Function(name: "nestedFunction", returnType: "Double?", arguments: [], defaultReturnValue: "nil")
+        ])
+    }
+    
+    func testProtocolEntity_WhenMultipleConformancesAndNesting_ThenHasDefinitionsFromAllProtocols() {
+        guard let entity = ProtocolParser.protocolEntity(with: "SomeProtocolComposition", in: [testFileWithMultipleConformancesAndNesting], defaultsTable: [:]) else { XCTFail(); return }
         
-        XCTAssertEqual(entity.variables[3].name, "myWeakGetSet")
-        XCTAssertEqual(entity.variables[3].type, "AmazingClass?")
-        XCTAssertEqual(entity.variables[3].isGetSet, true)
-        XCTAssertEqual(entity.variables[3].isWeak, true)
+        XCTAssertEqual(Set(entity.variables), [
+            Variable(name: "myVariable", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "myGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false),
+            Variable(name: "composedGet", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "composedGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false),
+            Variable(name: "nestedGet", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "nestedGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false),
+            Variable(name: "anotherComposedGet", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "anotherComposedGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false)
+        ])
+        
+        XCTAssertEqual(Set(entity.functions), [
+            Function(name: "woo", returnType: "Double?", arguments: [], defaultReturnValue: "nil"),
+            Function(name: "composedFunction", returnType: "Double?", arguments: [], defaultReturnValue: "nil"),
+            Function(name: "nestedFunction", returnType: "Double?", arguments: [], defaultReturnValue: "nil"),
+            Function(name: "anotherComposedFunction", returnType: "Double?", arguments: [], defaultReturnValue: "nil")
+        ])
+    }
+    
+    func testProtocolEntity_WhenDuplicateProtocolRequirements_ThenDoesNotDuplicateNeededDefinitions() {
+        guard let entity = ProtocolParser.protocolEntity(with: "SomeProtocolComposition", in: [testFileWithDuplicateConformances], defaultsTable: [:]) else { XCTFail(); return }
+
+        XCTAssertEqual(Set(entity.variables), [
+            Variable(name: "duplicateVariable", type: "String", defaultReturnValue: "\"\"", isGetSet: false, isWeak: false),
+            Variable(name: "myGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false),
+            Variable(name: "composedGetSet", type: "Int", defaultReturnValue: "0", isGetSet: true, isWeak: false)
+        ])
+        
+        XCTAssertEqual(Set(entity.functions), [
+            Function(name: "duplicateFunction", returnType: "Double?", arguments: [], defaultReturnValue: "nil"),
+            Function(name: "myFunc", returnType: "String", arguments: [], defaultReturnValue: "\"\""),
+            Function(name: "composedMyFunc", returnType: "String", arguments: [], defaultReturnValue: "\"\"")
+        ])
+    }
+    
+    // MARK: - protocolConformances
+    func testProtocolConformances_WhenNilFirstLine_EmptyArray() {
+        XCTAssertEqual(ProtocolParser.protocolConformances(fromProtocolFirstLine: nil), [])
+    }
+    
+    func testProtocolConformances_WhenNoConformances_EmptyArray() {
+        XCTAssertEqual(ProtocolParser.protocolConformances(fromProtocolFirstLine: "protocol Test {"), [])
+    }
+    
+    
+    func testProtocolConformances_WhenClassConformance_EmptyArray() {
+        XCTAssertEqual(ProtocolParser.protocolConformances(fromProtocolFirstLine: "protocol Test: class {"), [])
+    }
+    
+    func testProtocolConformances_WhenOneConformance_ReturnsConformance() {
+        XCTAssertEqual(ProtocolParser.protocolConformances(fromProtocolFirstLine: "protocol Test: TestConformance {"), ["TestConformance"])
+    }
+    
+    func testProtocolConformances_WhenMultipleConformance_ReturnsTrimmedConformances() {
+        XCTAssertEqual(ProtocolParser.protocolConformances(fromProtocolFirstLine: "protocol Test: TestConformance, SecondConformance, GoingCrazyNow {"), ["TestConformance", "SecondConformance", "GoingCrazyNow"])
+    }
+    
+    func testProtocolConformances_WhenMultipleConformanceAndClassConformance_ReturnsTrimmedConformancesWithoutClass() {
+        XCTAssertEqual(ProtocolParser.protocolConformances(fromProtocolFirstLine: "protocol Test: class, TestConformance, SecondConformance, GoingCrazyNow {"), ["TestConformance", "SecondConformance", "GoingCrazyNow"])
     }
 }
 
@@ -140,6 +194,91 @@ extension ProtocolParserTests {
             "weak var myWeakGetSet: AmazingClass? { set get }",
             "func woo() -> Double?",
             "}"
+        ]
+        return File(url: url, lines: lines)
+    }
+    
+    private var testFileWithProtocolComposition: File {
+        let url = URL(string: FileManager.default.currentDirectoryPath)!
+        let lines = [
+            "protocol SomeProtocolComposition: class, ComposedProtocol {",
+            " var myVariable : String { get }",
+            "var myGetSet : Int { get set }",
+            "func woo() -> Double?",
+            "}",
+            "protocol ComposedProtocol: class {",
+            " var composedGet : String { get }",
+            "var composedGetSet : Int { get set }",
+            "func composedFunction() -> Double?",
+            "}",
+        ]
+        return File(url: url, lines: lines)
+    }
+    
+    private var testFileWithNestedProtocolComposition: File {
+        let url = URL(string: FileManager.default.currentDirectoryPath)!
+        let lines = [
+            "protocol SomeProtocolComposition: class, ComposedProtocol {",
+            " var myVariable : String { get }",
+            "var myGetSet : Int { get set }",
+            "func woo() -> Double?",
+            "}",
+            "protocol ComposedProtocol: class, NestedComposition {",
+            " var composedGet : String { get }",
+            "var composedGetSet : Int { get set }",
+            "func composedFunction() -> Double?",
+            "}",
+            "protocol NestedComposition {",
+            " var nestedGet : String { get }",
+            "var nestedGetSet : Int { get set }",
+            "func nestedFunction() -> Double?",
+            "}",
+        ]
+        return File(url: url, lines: lines)
+    }
+    
+    private var testFileWithMultipleConformancesAndNesting: File {
+        let url = URL(string: FileManager.default.currentDirectoryPath)!
+        let lines = [
+            "protocol SomeProtocolComposition: class, ComposedProtocol, AnotherComposedProtocol {",
+            " var myVariable : String { get }",
+            "var myGetSet : Int { get set }",
+            "func woo() -> Double?",
+            "}",
+            "protocol AnotherComposedProtocol {",
+            " var anotherComposedGet : String { get }",
+            "var anotherComposedGetSet : Int { get set }",
+            "func anotherComposedFunction() -> Double?",
+            "}",
+            "protocol ComposedProtocol: class, NestedComposition {",
+            " var composedGet : String { get }",
+            "var composedGetSet : Int { get set }",
+            "func composedFunction() -> Double?",
+            "}",
+            "protocol NestedComposition {",
+            " var nestedGet : String { get }",
+            "var nestedGetSet : Int { get set }",
+            "func nestedFunction() -> Double?",
+            "}",
+        ]
+        return File(url: url, lines: lines)
+    }
+    
+    private var testFileWithDuplicateConformances: File {
+        let url = URL(string: FileManager.default.currentDirectoryPath)!
+        let lines = [
+            "protocol SomeProtocolComposition: class, ComposedProtocol {",
+            " var duplicateVariable : String { get }",
+            "var myGetSet : Int { get set }",
+            "func duplicateFunction() -> Double?",
+            "func myFunc() -> String",
+            "}",
+            "protocol ComposedProtocol: class {",
+            " var duplicateVariable : String { get }",
+            "var composedGetSet : Int { get set }",
+            "func duplicateFunction() -> Double?",
+            "func composedMyFunc() -> String",
+            "}",
         ]
         return File(url: url, lines: lines)
     }

--- a/ParrotTests/RunExamples/Implementation/CompositionExamples.swift
+++ b/ParrotTests/RunExamples/Implementation/CompositionExamples.swift
@@ -1,0 +1,25 @@
+protocol MyConformingProtocol: ProtocolToConformTo {
+    func myFunction()
+}
+
+protocol ProtocolToConformTo {
+    var myString: String { get }
+}
+
+protocol NestedConformingProtocol: MyConformingProtocol {
+    func mySecondFunction()
+}
+
+protocol MySecondConformingProtocol: class, ProtocolWithDuplicateRequirements {
+    func duplicateFunction(test: [String]) -> Int?
+    var nonDuplicateGet: Int { get }
+    var duplicateDelegate: SomeProtocol? { get set }
+    func nonDuplicateFunction() -> Set<String>
+}
+
+internal protocol ProtocolWithDuplicateRequirements {
+    var duplicateDelegate: SomeProtocol? { get set }
+    func duplicateFunction(test: [String]) -> Int?
+    var nonDuplicateGetSet: Int { get set }
+    func nonDuplicateFunction() -> Set<Int>
+}

--- a/ParrotTests/RunExamples/Tests/MockCustom.swift
+++ b/ParrotTests/RunExamples/Tests/MockCustom.swift
@@ -3,14 +3,14 @@
 class MockCustom: CustomProtocol {
 
 	final class Stub {
-		var customThingCallCount = 0
-		var customThingShouldReturn: Custom = Custom(propertyString: "", propertyInt: 0)
-		var customProtocolThingGetSetCallCount = 0
-		var customProtocolThingGetSetShouldReturn: CustomProtocol = Custom(propertyString: "protocol", propertyInt: 1)
-		var customThingGetSetCallCount = 0
-		var customThingGetSetShouldReturn: Custom = Custom(propertyString: "", propertyInt: 0)
 		var customProtocolThingCallCount = 0
 		var customProtocolThingShouldReturn: CustomProtocol = Custom(propertyString: "protocol", propertyInt: 1)
+		var customProtocolThingGetSetCallCount = 0
+		var customProtocolThingGetSetShouldReturn: CustomProtocol = Custom(propertyString: "protocol", propertyInt: 1)
+		var customThingCallCount = 0
+		var customThingShouldReturn: Custom = Custom(propertyString: "", propertyInt: 0)
+		var customThingGetSetCallCount = 0
+		var customThingGetSetShouldReturn: Custom = Custom(propertyString: "", propertyInt: 0)
 		var returnCustomCallCount = 0
 		var returnCustomShouldReturn: AnotherCustom = AnotherCustom(custom: Custom(propertyString: "", propertyInt: 0))
 		var returnCustomFormattedCallCount = 0
@@ -39,14 +39,14 @@ class MockCustom: CustomProtocol {
 		}
 	}
 
-	var customProtocolThing: CustomProtocol {
-		stub.customProtocolThingCallCount += 1
-		return stub.customProtocolThingShouldReturn
-	}
-
 	var customThing: Custom {
 		stub.customThingCallCount += 1
 		return stub.customThingShouldReturn
+	}
+
+	var customProtocolThing: CustomProtocol {
+		stub.customProtocolThingCallCount += 1
+		return stub.customProtocolThingShouldReturn
 	}
 
 	func returnCustom() -> AnotherCustom {

--- a/ParrotTests/RunExamples/Tests/MockDictionaryExamples.swift
+++ b/ParrotTests/RunExamples/Tests/MockDictionaryExamples.swift
@@ -7,16 +7,16 @@ class MockSimpleDictionaryExamples: DictionaryExamples {
 		var varGetDictionaryShouldReturn: [String: String] = [:]
 		var varGetSetDictionaryCallCount = 0
 		var varGetSetDictionaryShouldReturn: [String: String] = [:]
-		var testDictionarySimpleCallCount = 0
-		var testDictionarySimpleCalledWith = [[String: Any]]()
-		var testDictionaryReturnSimpleCallCount = 0
-		var testDictionaryReturnSimpleShouldReturn: [String: Any] = [:]
 		var testDictionaryDictionaryArgAndReturnCallCount = 0
 		var testDictionaryDictionaryArgAndReturnCalledWith = [[String: [String]]]()
 		var testDictionaryDictionaryArgAndReturnShouldReturn: [Int: [Int]] = [:]
 		var testDictionaryOptionalsCallCount = 0
 		var testDictionaryOptionalsCalledWith = [[String: [String: Any]]?]()
 		var testDictionaryOptionalsShouldReturn: [String: String]? = nil
+		var testDictionaryReturnSimpleCallCount = 0
+		var testDictionaryReturnSimpleShouldReturn: [String: Any] = [:]
+		var testDictionarySimpleCallCount = 0
+		var testDictionarySimpleCalledWith = [[String: Any]]()
 	}
 
 	var stub = Stub()
@@ -36,16 +36,6 @@ class MockSimpleDictionaryExamples: DictionaryExamples {
 		return stub.varGetDictionaryShouldReturn
 	}
 
-	func testDictionarySimple(myDictionary: [String: Any]) {
-		stub.testDictionarySimpleCallCount += 1
-		stub.testDictionarySimpleCalledWith.append(myDictionary)
-	}
-
-	func testDictionaryReturnSimple() -> [String: Any] {
-		stub.testDictionaryReturnSimpleCallCount += 1
-		return stub.testDictionaryReturnSimpleShouldReturn
-	}
-
 	func testDictionaryDictionaryArgAndReturn(my dictionary: [String: [String]]) -> [Int: [Int]] {
 		stub.testDictionaryDictionaryArgAndReturnCallCount += 1
 		stub.testDictionaryDictionaryArgAndReturnCalledWith.append(dictionary)
@@ -56,6 +46,16 @@ class MockSimpleDictionaryExamples: DictionaryExamples {
 		stub.testDictionaryOptionalsCallCount += 1
 		stub.testDictionaryOptionalsCalledWith.append(optionalDictionary)
 		return stub.testDictionaryOptionalsShouldReturn
+	}
+
+	func testDictionaryReturnSimple() -> [String: Any] {
+		stub.testDictionaryReturnSimpleCallCount += 1
+		return stub.testDictionaryReturnSimpleShouldReturn
+	}
+
+	func testDictionarySimple(myDictionary: [String: Any]) {
+		stub.testDictionarySimpleCallCount += 1
+		stub.testDictionarySimpleCalledWith.append(myDictionary)
 	}
 
 }

--- a/ParrotTests/RunExamples/Tests/MockMyConformingProtocol.swift
+++ b/ParrotTests/RunExamples/Tests/MockMyConformingProtocol.swift
@@ -1,0 +1,22 @@
+
+//@@parrot-mock
+final class MockMyConformingProtocol: MyConformingProtocol {
+
+	final class Stub {
+		var myStringCallCount = 0
+		var myStringShouldReturn: String = ""
+		var myFunctionCallCount = 0
+	}
+
+	var stub = Stub()
+
+	var myString: String {
+		stub.myStringCallCount += 1
+		return stub.myStringShouldReturn
+	}
+
+	func myFunction() {
+		stub.myFunctionCallCount += 1
+	}
+
+}

--- a/ParrotTests/RunExamples/Tests/MockMySecondConformingProtocol.swift
+++ b/ParrotTests/RunExamples/Tests/MockMySecondConformingProtocol.swift
@@ -1,0 +1,64 @@
+
+//@@parrot-mock
+final class MockMySecondConformingProtocol: MySecondConformingProtocol {
+
+	final class Stub {
+		var duplicateDelegateCallCount = 0
+		var duplicateDelegateShouldReturn: SomeProtocol?
+		var nonDuplicateGetCallCount = 0
+		var nonDuplicateGetShouldReturn: Int = 0
+		var nonDuplicateGetSetCallCount = 0
+		var nonDuplicateGetSetShouldReturn: Int = 0
+		var duplicateFunctionCallCount = 0
+		var duplicateFunctionCalledWith = [[String]]()
+		var duplicateFunctionShouldReturn: Int? = nil
+		var nonDuplicateFunctionReturnsSetOfStringsCallCount = 0
+		var nonDuplicateFunctionReturnsSetOfStringsShouldReturn: Set<String> = []
+		var nonDuplicateFunctionReturnsSetOfIntsCallCount = 0
+		var nonDuplicateFunctionReturnsSetOfIntsShouldReturn: Set<Int> = []
+	}
+
+	var stub = Stub()
+
+	var nonDuplicateGetSet: Int {
+		get {
+			stub.nonDuplicateGetSetCallCount += 1
+			return stub.nonDuplicateGetSetShouldReturn
+		}
+		set {
+			stub.nonDuplicateGetSetShouldReturn = newValue
+		}
+	}
+
+	var duplicateDelegate: SomeProtocol? {
+		get {
+			stub.duplicateDelegateCallCount += 1
+			return stub.duplicateDelegateShouldReturn
+		}
+		set {
+			stub.duplicateDelegateShouldReturn = newValue
+		}
+	}
+
+	var nonDuplicateGet: Int {
+		stub.nonDuplicateGetCallCount += 1
+		return stub.nonDuplicateGetShouldReturn
+	}
+
+	func duplicateFunction(test: [String]) -> Int? {
+		stub.duplicateFunctionCallCount += 1
+		stub.duplicateFunctionCalledWith.append(test)
+		return stub.duplicateFunctionShouldReturn
+	}
+
+	func nonDuplicateFunction() -> Set<String> {
+		stub.nonDuplicateFunctionReturnsSetOfStringsCallCount += 1
+		return stub.nonDuplicateFunctionReturnsSetOfStringsShouldReturn
+	}
+
+	func nonDuplicateFunction() -> Set<Int> {
+		stub.nonDuplicateFunctionReturnsSetOfIntsCallCount += 1
+		return stub.nonDuplicateFunctionReturnsSetOfIntsShouldReturn
+	}
+
+}

--- a/ParrotTests/RunExamples/Tests/MockNestedConformingProtocol.swift
+++ b/ParrotTests/RunExamples/Tests/MockNestedConformingProtocol.swift
@@ -1,0 +1,27 @@
+
+//@@parrot-mock
+final class MockNestedConformingProtocol: NestedConformingProtocol {
+
+	final class Stub {
+		var myStringCallCount = 0
+		var myStringShouldReturn: String = ""
+		var myFunctionCallCount = 0
+		var mySecondFunctionCallCount = 0
+	}
+
+	var stub = Stub()
+
+	var myString: String {
+		stub.myStringCallCount += 1
+		return stub.myStringShouldReturn
+	}
+
+	func myFunction() {
+		stub.myFunctionCallCount += 1
+	}
+
+	func mySecondFunction() {
+		stub.mySecondFunctionCallCount += 1
+	}
+
+}

--- a/ParrotTests/RunExamples/Tests/MockOverloadedFunctionsExample.swift
+++ b/ParrotTests/RunExamples/Tests/MockOverloadedFunctionsExample.swift
@@ -5,15 +5,15 @@ class MockOverloadedFunctionsExample: OverloadedFunctionExample {
 	final class Stub {
 		var answersCallCount = 0
 		var answersShouldReturn: [String] = []
+		var answersForArchivedReturnsIntCallCount = 0
+		var answersForArchivedReturnsIntCalledWith = [(id: String, archived: Bool)]()
+		var answersForArchivedReturnsIntShouldReturn: Int = 0
+		var answersForArchivedReturnsVoidCallCount = 0
+		var answersForArchivedReturnsVoidCalledWith = [(id: String, archived: Bool)]()
 		var answersForCallCount = 0
 		var answersForCalledWith = [String]()
 		var answersInCallCount = 0
 		var answersInCalledWith = [[String]]()
-		var answersForArchivedReturnsVoidCallCount = 0
-		var answersForArchivedReturnsVoidCalledWith = [(id: String, archived: Bool)]()
-		var answersForArchivedReturnsIntCallCount = 0
-		var answersForArchivedReturnsIntCalledWith = [(id: String, archived: Bool)]()
-		var answersForArchivedReturnsIntShouldReturn: Int = 0
 	}
 
 	var stub = Stub()
@@ -21,6 +21,17 @@ class MockOverloadedFunctionsExample: OverloadedFunctionExample {
 	var answers: [String] {
 		stub.answersCallCount += 1
 		return stub.answersShouldReturn
+	}
+
+	func answers(for id: String, archived: Bool) -> Int {
+		stub.answersForArchivedReturnsIntCallCount += 1
+		stub.answersForArchivedReturnsIntCalledWith.append((id, archived))
+		return stub.answersForArchivedReturnsIntShouldReturn
+	}
+
+	func answers(for id: String, archived: Bool) {
+		stub.answersForArchivedReturnsVoidCallCount += 1
+		stub.answersForArchivedReturnsVoidCalledWith.append((id, archived))
 	}
 
 	func answers(for id: String) {
@@ -31,17 +42,6 @@ class MockOverloadedFunctionsExample: OverloadedFunctionExample {
 	func answers(in ids: [String]) {
 		stub.answersInCallCount += 1
 		stub.answersInCalledWith.append(ids)
-	}
-
-	func answers(for id: String, archived: Bool) {
-		stub.answersForArchivedReturnsVoidCallCount += 1
-		stub.answersForArchivedReturnsVoidCalledWith.append((id, archived))
-	}
-
-	func answers(for id: String, archived: Bool) -> Int {
-		stub.answersForArchivedReturnsIntCallCount += 1
-		stub.answersForArchivedReturnsIntCalledWith.append((id, archived))
-		return stub.answersForArchivedReturnsIntShouldReturn
 	}
 
 }

--- a/ParrotTests/RunExamples/Tests/MockSomeOptionalThings.swift
+++ b/ParrotTests/RunExamples/Tests/MockSomeOptionalThings.swift
@@ -3,10 +3,6 @@
 final class MockSomeOptionalThings: SomeOptionalThings {
 
 	final class Stub {
-		var myVariableCallCount = 0
-		var myVariableShouldReturn: String?
-		var myGetSetCallCount = 0
-		var myGetSetShouldReturn: String?
 		var myArrayGetCallCount = 0
 		var myArrayGetShouldReturn: [String]?
 		var myArrayGetOptionalElementCallCount = 0
@@ -17,10 +13,14 @@ final class MockSomeOptionalThings: SomeOptionalThings {
 		var myDictionaryGetOptionalValueShouldReturn: [String: String?] = [:]
 		var myDictionaryGetOptionalValueAndSelfCallCount = 0
 		var myDictionaryGetOptionalValueAndSelfShouldReturn: [String: String?]?
+		var myGetSetCallCount = 0
+		var myGetSetShouldReturn: String?
 		var mySetOfDoublesGetCallCount = 0
 		var mySetOfDoublesGetShouldReturn: Set<Double>?
 		var mySetOfDoublesGetOptionalElementCallCount = 0
 		var mySetOfDoublesGetOptionalElementShouldReturn: Set<Double?> = []
+		var myVariableCallCount = 0
+		var myVariableShouldReturn: String?
 		var myWeakGetCallCount = 0
 		var myWeakGetShouldReturn: AmazingClass?
 		var myWeakGetSetCallCount = 0
@@ -48,6 +48,11 @@ final class MockSomeOptionalThings: SomeOptionalThings {
 		set {
 			stub.myWeakGetSetShouldReturn = newValue
 		}
+	}
+
+	var myVariable: String? {
+		stub.myVariableCallCount += 1
+		return stub.myVariableShouldReturn
 	}
 
 	var mySetOfDoublesGetOptionalElement: Set<Double?> {
@@ -83,11 +88,6 @@ final class MockSomeOptionalThings: SomeOptionalThings {
 	var myArrayGet: [String]? {
 		stub.myArrayGetCallCount += 1
 		return stub.myArrayGetShouldReturn
-	}
-
-	var myVariable: String? {
-		stub.myVariableCallCount += 1
-		return stub.myVariableShouldReturn
 	}
 
 	weak var myWeakGet: AmazingClass? {

--- a/ParrotTests/RunExamples/Tests/TestFile.swift
+++ b/ParrotTests/RunExamples/Tests/TestFile.swift
@@ -7,25 +7,25 @@ import XCTest
 final class MockModel: SomeProtocol {
 
 	final class Stub {
-		var myVariableCallCount = 0
-		var myVariableShouldReturn: String = ""
-		var myGetSetCallCount = 0
-		var myGetSetShouldReturn: String = ""
 		var myArrayGetCallCount = 0
 		var myArrayGetShouldReturn: [String] = []
+		var myGetSetCallCount = 0
+		var myGetSetShouldReturn: String = ""
 		var mySetOfDoublesGetCallCount = 0
 		var mySetOfDoublesGetShouldReturn: Set<Double> = []
+		var myVariableCallCount = 0
+		var myVariableShouldReturn: String = ""
 		var myWeakGetCallCount = 0
 		var myWeakGetShouldReturn: AmazingClass?
 		var myWeakGetSetCallCount = 0
 		var myWeakGetSetShouldReturn: AmazingClass?
 		var myBasicFuncCallCount = 0
-		var myBasicFuncTwoCallCount = 0
-		var myBasicFuncTwoCalledWith = [String]()
-		var myBasicFuncTwoShouldReturn: Int = 0
 		var myBasicFuncThreeCallCount = 0
 		var myBasicFuncThreeCalledWith = [(name: String, age: Int, address: String)]()
 		var myBasicFuncThreeShouldReturn: String? = nil
+		var myBasicFuncTwoCallCount = 0
+		var myBasicFuncTwoCalledWith = [String]()
+		var myBasicFuncTwoShouldReturn: Int = 0
 		var myFuncWithCallCount = 0
 		var myFuncWithCalledWith = [String]()
 	}
@@ -52,6 +52,11 @@ final class MockModel: SomeProtocol {
 		}
 	}
 
+	var myVariable: String {
+		stub.myVariableCallCount += 1
+		return stub.myVariableShouldReturn
+	}
+
 	var mySetOfDoublesGet: Set<Double> {
 		stub.mySetOfDoublesGetCallCount += 1
 		return stub.mySetOfDoublesGetShouldReturn
@@ -60,11 +65,6 @@ final class MockModel: SomeProtocol {
 	var myArrayGet: [String] {
 		stub.myArrayGetCallCount += 1
 		return stub.myArrayGetShouldReturn
-	}
-
-	var myVariable: String {
-		stub.myVariableCallCount += 1
-		return stub.myVariableShouldReturn
 	}
 
 	weak var myWeakGet: AmazingClass? {
@@ -76,16 +76,16 @@ final class MockModel: SomeProtocol {
 		stub.myBasicFuncCallCount += 1
 	}
 
-	func myBasicFuncTwo(name: String) -> Int {
-		stub.myBasicFuncTwoCallCount += 1
-		stub.myBasicFuncTwoCalledWith.append(name)
-		return stub.myBasicFuncTwoShouldReturn
-	}
-
 	func myBasicFuncThree(name: String, age: Int, address: String) -> String? {
 		stub.myBasicFuncThreeCallCount += 1
 		stub.myBasicFuncThreeCalledWith.append((name, age, address))
 		return stub.myBasicFuncThreeShouldReturn
+	}
+
+	func myBasicFuncTwo(name: String) -> Int {
+		stub.myBasicFuncTwoCallCount += 1
+		stub.myBasicFuncTwoCalledWith.append(name)
+		return stub.myBasicFuncTwoShouldReturn
 	}
 
 	func myFuncWith(external name: String) {


### PR DESCRIPTION
… using a Set to disallow duplicate conformances between composition so now sorting the variables and functions by name to make mock generation order less random (still changes order from how it was defined in the protocol). Variable, Function, and Argument are now Hashable to support Sets

fixes #7 