### PR TITLE
ParrotResetMock & Swift 5

### DIFF
--- a/Parrot.xcodeproj/project.pbxproj
+++ b/Parrot.xcodeproj/project.pbxproj
@@ -374,10 +374,12 @@
 				TargetAttributes = {
 					F3673E4E1FBE237D00D5F026 = {
 						CreatedOnToolsVersion = 9.1;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					F3673E6C1FBE277E00D5F026 = {
 						CreatedOnToolsVersion = 9.1;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -634,7 +636,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/ParrotTests/Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -647,7 +649,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/ParrotTests/Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -661,7 +663,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.monsanto.tps.ParrotTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -675,7 +677,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.monsanto.tps.ParrotTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Parrot/Mock Generation/MockGenerator.swift
+++ b/Parrot/Mock Generation/MockGenerator.swift
@@ -55,6 +55,10 @@ struct MockGenerator {
         
         \tvar stub = Stub()
         
+        \tfunc parrotResetMock() {
+        \t\tstub = Stub()
+        \t}
+        
         \(formattedGetSetVariables.isEmpty ? "" : formattedGetSetVariables + "\n\n" )\(formattedGetVariables.isEmpty ? "" : formattedGetVariables + "\n")\(formattedFunctions)
         }
         """

--- a/Parrot/Parsing/DefaultsParser.swift
+++ b/Parrot/Parsing/DefaultsParser.swift
@@ -6,7 +6,7 @@ struct DefaultsParser {
         for line in lines {
             guard line.hasPrefix("let") else { continue }
             
-            guard let colonIndex = line.index(of: ":"), let equalsIndex = line.index(of: "=") else { continue }
+            guard let colonIndex = line.firstIndex(of: ":"), let equalsIndex = line.firstIndex(of: "=") else { continue }
             
             let type = line[colonIndex.indexPlusOne..<equalsIndex].toTrimmedString
             

--- a/Parrot/Util/ArrayExtensions.swift
+++ b/Parrot/Util/ArrayExtensions.swift
@@ -56,7 +56,7 @@ extension Array where Element == Function {
                         switch knownType {
                         case .arrayType: return "ReturnsArrayOf\(functionReturnType.dropFirst().dropLast())s"
                         case .dictionaryType:
-                            let indexOfColon = functionReturnType.index(of: ":")!
+                            let indexOfColon = functionReturnType.firstIndex(of: ":")!
                             return "ReturnsDictionaryOf\(functionReturnType[..<indexOfColon].dropFirst().toTrimmedString)To\(functionReturnType[indexOfColon...].dropFirst().dropLast().toTrimmedString)"
 
                         case .optionalType: return "ReturnsOptional\(functionReturnType.dropLast())"

--- a/Parrot/Util/Log.swift
+++ b/Parrot/Util/Log.swift
@@ -31,7 +31,7 @@ struct Log {
     }
     
     private static func name(fromFunctionString string: String) -> String {
-        if let index = string.index(of: "(") {
+        if let index = string.firstIndex(of: "(") {
             return "\(String(string[..<index]))()"
         }
         return string

--- a/Parrot/Util/StringExtensions.swift
+++ b/Parrot/Util/StringExtensions.swift
@@ -90,7 +90,7 @@ extension String {
         var separatorIndexes = [String.Index]()
         var currentSubString: Substring = Substring(self)
         
-        while let enclosingCharacterIndex = currentSubString.index(of: ",") {
+        while let enclosingCharacterIndex = currentSubString.firstIndex(of: ",") {
             
             if enclosingCharacterIndex.isNotContainedIn(ranges: ranges) {
                 separatorIndexes.append(enclosingCharacterIndex)

--- a/ParrotTests/BasicExamplesToCover.swift
+++ b/ParrotTests/BasicExamplesToCover.swift
@@ -61,9 +61,10 @@ protocol SampleDelegate: class {
     func dataRefreshed()
 }
 
+// TODO: Check that this still works with weak removed
 protocol VariableProtocolWithWeak {
-    weak var weakDelegateGet: SampleDelegate? { get }
-    weak var weakDelegateGetSet: SampleDelegate? { get set }
+    var weakDelegateGet: SampleDelegate? { get }
+    var weakDelegateGetSet: SampleDelegate? { get set }
 }
 
 

--- a/ParrotTests/Mock Generation Tests/MockGeneratorTests.swift
+++ b/ParrotTests/Mock Generation Tests/MockGeneratorTests.swift
@@ -36,4 +36,18 @@ class MockGeneratorTests: XCTestCase {
         
         XCTAssertEqual(MockGenerator.formattedGetSetVariable(mockImplementationLines: mockImplementationLines), expectedFormat)
     }
+    
+    func testFileContents_IncludesAResetMockFunction() {
+        let mockFile = File(url: URL(fileURLWithPath: ""), lines: ["protocol Test {", "}", "//@@parrot-mock", "class TestClass: Test {", "}"])
+        let mockMockEntity = MockEntity(file: mockFile, headers: [], type: "Test", name: "TestClass", protocolName: "Test")
+        let mockProtocolEntity = ProtocolEntity(file: mockFile, name: "Test", variables: [], functions: [])
+        
+        let expectedStubReset = """
+        \tfunc parrotResetMock() {
+        \t\tstub = Stub()
+        \t}
+        """
+        let fileContents = MockGenerator.fileContents(from: mockProtocolEntity, for: mockMockEntity)
+        XCTAssertTrue(fileContents.contains(expectedStubReset))
+    }
 }

--- a/ParrotTests/RunExamples/Implementation/Implementation.swift
+++ b/ParrotTests/RunExamples/Implementation/Implementation.swift
@@ -7,6 +7,7 @@ protocol TheWrongProtocol {
 
 }
 
+// TODO: Check that the weak vars still work
 protocol SomeProtocol: class {
     var myVariable: String { get }
     var myGetSet: String { get set }
@@ -14,8 +15,8 @@ protocol SomeProtocol: class {
     var myArrayGet: [String] { get }
     var mySetOfDoublesGet: Set<Double> { get }
     
-    weak var myWeakGet: AmazingClass? { get }
-    weak var myWeakGetSet: AmazingClass? { get set }
+    var myWeakGet: AmazingClass? { get }
+    var myWeakGetSet: AmazingClass? { get set }
     
     func myBasicFunc()
     func myBasicFuncTwo(name: String) -> Int
@@ -39,7 +40,7 @@ protocol SomeOptionalThings {
     var mySetOfDoublesGet: Set<Double>? { get }
     var mySetOfDoublesGetOptionalElement: Set<Double?> { get }
     
-    weak var myWeakGet: AmazingClass? { get }
-    weak var myWeakGetSet: AmazingClass? { get set }
+    var myWeakGet: AmazingClass? { get }
+    var myWeakGetSet: AmazingClass? { get set }
     
 }

--- a/ParrotTests/RunExamples/Tests/MockComplexDictionaryExamples.swift
+++ b/ParrotTests/RunExamples/Tests/MockComplexDictionaryExamples.swift
@@ -14,6 +14,10 @@ class MockComplexDictionaryExmaples: ComplexDictionaryExamples {
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	func testCompletionAndDictionary(parameters: [String: String], completion: @escaping (String?, String?) -> ()) -> [String: Any]? {
 		stub.testCompletionAndDictionaryCallCount += 1
 		stub.testCompletionAndDictionaryCalledWith.append((parameters, completion))

--- a/ParrotTests/RunExamples/Tests/MockCustom.swift
+++ b/ParrotTests/RunExamples/Tests/MockCustom.swift
@@ -19,6 +19,10 @@ class MockCustom: CustomProtocol {
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	var customThingGetSet: Custom {
 		get {
 			stub.customThingGetSetCallCount += 1

--- a/ParrotTests/RunExamples/Tests/MockDictionaryExamples.swift
+++ b/ParrotTests/RunExamples/Tests/MockDictionaryExamples.swift
@@ -21,6 +21,10 @@ class MockSimpleDictionaryExamples: DictionaryExamples {
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	var varGetSetDictionary: [String: String] {
 		get {
 			stub.varGetSetDictionaryCallCount += 1

--- a/ParrotTests/RunExamples/Tests/MockExampleDataFetchWithMultipleCompletionParameters.swift
+++ b/ParrotTests/RunExamples/Tests/MockExampleDataFetchWithMultipleCompletionParameters.swift
@@ -10,6 +10,10 @@ class MockExampleDataFetcherWithMultipleCompletionParameters: ExampleDataFetcher
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	func fetch(completion: @escaping (String?, String?) -> ()) {
 		stub.fetchCallCount += 1
 		stub.fetchCalledWith.append(completion)

--- a/ParrotTests/RunExamples/Tests/MockExampleDataFetcher.swift
+++ b/ParrotTests/RunExamples/Tests/MockExampleDataFetcher.swift
@@ -10,6 +10,10 @@ class MockExampleDataFetcher: ExampleDataFetcher {
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	func fetch(completion: @escaping () -> ()) {
 		stub.fetchCallCount += 1
 		stub.fetchCalledWith.append(completion)

--- a/ParrotTests/RunExamples/Tests/MockExampleDataFetcherWithCompletionParameter.swift
+++ b/ParrotTests/RunExamples/Tests/MockExampleDataFetcherWithCompletionParameter.swift
@@ -10,6 +10,10 @@ class MockExampleDataFetcherWithCompletionParameters: ExampleDataFetcherWithComp
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	func fetch(completion: @escaping ([String]) -> ()) {
 		stub.fetchCallCount += 1
 		stub.fetchCalledWith.append(completion)

--- a/ParrotTests/RunExamples/Tests/MockExampleDataFetcherWithOtherParameter.swift
+++ b/ParrotTests/RunExamples/Tests/MockExampleDataFetcherWithOtherParameter.swift
@@ -10,6 +10,10 @@ class MockExampleDataFetcherWithOtherParameter: ExampleDataFetcherWithOtherParam
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	func fetch(options: Bool, completion: @escaping () -> ()) {
 		stub.fetchCallCount += 1
 		stub.fetchCalledWith.append((options, completion))

--- a/ParrotTests/RunExamples/Tests/MockMyConformingProtocol.swift
+++ b/ParrotTests/RunExamples/Tests/MockMyConformingProtocol.swift
@@ -10,6 +10,10 @@ final class MockMyConformingProtocol: MyConformingProtocol {
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	var myString: String {
 		stub.myStringCallCount += 1
 		return stub.myStringShouldReturn

--- a/ParrotTests/RunExamples/Tests/MockMySecondConformingProtocol.swift
+++ b/ParrotTests/RunExamples/Tests/MockMySecondConformingProtocol.swift
@@ -20,6 +20,10 @@ final class MockMySecondConformingProtocol: MySecondConformingProtocol {
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	var nonDuplicateGetSet: Int {
 		get {
 			stub.nonDuplicateGetSetCallCount += 1

--- a/ParrotTests/RunExamples/Tests/MockNestedConformingProtocol.swift
+++ b/ParrotTests/RunExamples/Tests/MockNestedConformingProtocol.swift
@@ -11,6 +11,10 @@ final class MockNestedConformingProtocol: NestedConformingProtocol {
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	var myString: String {
 		stub.myStringCallCount += 1
 		return stub.myStringShouldReturn

--- a/ParrotTests/RunExamples/Tests/MockOverloadedFunctionsExample.swift
+++ b/ParrotTests/RunExamples/Tests/MockOverloadedFunctionsExample.swift
@@ -1,15 +1,15 @@
-
+#warning("TODO: Behavior for this one is crazy, not keeping things ordered and answerFor sometimes generates twice instead of renaming properly")
 //@@parrot-mock
 class MockOverloadedFunctionsExample: OverloadedFunctionExample {
 
 	final class Stub {
 		var answersCallCount = 0
 		var answersShouldReturn: [String] = []
+		var answersForArchivedReturnsVoidCallCount = 0
+		var answersForArchivedReturnsVoidCalledWith = [(id: String, archived: Bool)]()
 		var answersForArchivedReturnsIntCallCount = 0
 		var answersForArchivedReturnsIntCalledWith = [(id: String, archived: Bool)]()
 		var answersForArchivedReturnsIntShouldReturn: Int = 0
-		var answersForArchivedReturnsVoidCallCount = 0
-		var answersForArchivedReturnsVoidCalledWith = [(id: String, archived: Bool)]()
 		var answersForCallCount = 0
 		var answersForCalledWith = [String]()
 		var answersInCallCount = 0
@@ -18,20 +18,24 @@ class MockOverloadedFunctionsExample: OverloadedFunctionExample {
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
 	var answers: [String] {
 		stub.answersCallCount += 1
 		return stub.answersShouldReturn
+	}
+
+	func answers(for id: String, archived: Bool) {
+		stub.answersForArchivedReturnsVoidCallCount += 1
+		stub.answersForArchivedReturnsVoidCalledWith.append((id, archived))
 	}
 
 	func answers(for id: String, archived: Bool) -> Int {
 		stub.answersForArchivedReturnsIntCallCount += 1
 		stub.answersForArchivedReturnsIntCalledWith.append((id, archived))
 		return stub.answersForArchivedReturnsIntShouldReturn
-	}
-
-	func answers(for id: String, archived: Bool) {
-		stub.answersForArchivedReturnsVoidCallCount += 1
-		stub.answersForArchivedReturnsVoidCalledWith.append((id, archived))
 	}
 
 	func answers(for id: String) {

--- a/ParrotTests/RunExamples/Tests/MockSomeOptionalThings.swift
+++ b/ParrotTests/RunExamples/Tests/MockSomeOptionalThings.swift
@@ -30,6 +30,20 @@ final class MockSomeOptionalThings: SomeOptionalThings {
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
+	var myWeakGetSet: AmazingClass? {
+		get {
+			stub.myWeakGetSetCallCount += 1
+			return stub.myWeakGetSetShouldReturn
+		}
+		set {
+			stub.myWeakGetSetShouldReturn = newValue
+		}
+	}
+
 	var myGetSet: String? {
 		get {
 			stub.myGetSetCallCount += 1
@@ -40,14 +54,9 @@ final class MockSomeOptionalThings: SomeOptionalThings {
 		}
 	}
 
-	weak var myWeakGetSet: AmazingClass? {
-		get {
-			stub.myWeakGetSetCallCount += 1
-			return stub.myWeakGetSetShouldReturn
-		}
-		set {
-			stub.myWeakGetSetShouldReturn = newValue
-		}
+	var myWeakGet: AmazingClass? {
+		stub.myWeakGetCallCount += 1
+		return stub.myWeakGetShouldReturn
 	}
 
 	var myVariable: String? {
@@ -88,11 +97,6 @@ final class MockSomeOptionalThings: SomeOptionalThings {
 	var myArrayGet: [String]? {
 		stub.myArrayGetCallCount += 1
 		return stub.myArrayGetShouldReturn
-	}
-
-	weak var myWeakGet: AmazingClass? {
-		stub.myWeakGetCallCount += 1
-		return stub.myWeakGetShouldReturn
 	}
 
 

--- a/ParrotTests/RunExamples/Tests/TestFile.swift
+++ b/ParrotTests/RunExamples/Tests/TestFile.swift
@@ -32,6 +32,20 @@ final class MockModel: SomeProtocol {
 
 	var stub = Stub()
 
+	func parrotResetMock() {
+		stub = Stub()
+	}
+
+	var myWeakGetSet: AmazingClass? {
+		get {
+			stub.myWeakGetSetCallCount += 1
+			return stub.myWeakGetSetShouldReturn
+		}
+		set {
+			stub.myWeakGetSetShouldReturn = newValue
+		}
+	}
+
 	var myGetSet: String {
 		get {
 			stub.myGetSetCallCount += 1
@@ -42,14 +56,9 @@ final class MockModel: SomeProtocol {
 		}
 	}
 
-	weak var myWeakGetSet: AmazingClass? {
-		get {
-			stub.myWeakGetSetCallCount += 1
-			return stub.myWeakGetSetShouldReturn
-		}
-		set {
-			stub.myWeakGetSetShouldReturn = newValue
-		}
+	var myWeakGet: AmazingClass? {
+		stub.myWeakGetCallCount += 1
+		return stub.myWeakGetShouldReturn
 	}
 
 	var myVariable: String {
@@ -65,11 +74,6 @@ final class MockModel: SomeProtocol {
 	var myArrayGet: [String] {
 		stub.myArrayGetCallCount += 1
 		return stub.myArrayGetShouldReturn
-	}
-
-	weak var myWeakGet: AmazingClass? {
-		stub.myWeakGetCallCount += 1
-		return stub.myWeakGetShouldReturn
 	}
 
 	func myBasicFunc() {

--- a/ParrotTests/RunExamples/Tests/parrot-defaults.swift
+++ b/ParrotTests/RunExamples/Tests/parrot-defaults.swift
@@ -1,4 +1,8 @@
+import Foundation
+
 let parrot_customThing: Custom = Custom(propertyString: "", propertyInt: 0)
 let parrot_anotherCustom: AnotherCustom = AnotherCustom(custom: Custom(propertyString: "", propertyInt: 0))
 let parrot_customProtocol: CustomProtocol = Custom(propertyString: "protocol", propertyInt: 1)
 let parrot_customFunction: (String?, Int?) -> () = { _, _ in } // This shouldn't be necessary
+let parrot_Date: Date = Date()
+let parrot_Uuid: UUID = UUID()


### PR DESCRIPTION
- New function available in all mocks called parrotResetMock. Calling this function will reset the stub member of the mock to allow more verbose testing.
  - Example: The init of a struct/class calls function a. The function being tested also calls function a. Call mock.parrotResetMock() to reset the call count on the stub member for a clear functionACallCount == 1 assertion for the function being tested.
- Small changes for conversion to Swift 5

### Still TODO:
- There's deprecated encoded offset functions being used that need to be switched to utf16offset according to the compiler warning
- It's deprecated to use the property descriptor weak. It's been removed from all examples, but the handling of it is remaining implemented because it is just deprecated for now. Tests and examples all pass and compile respectively, but more testing could be done to ensure no regressions.